### PR TITLE
Fixed #49 Update pip-tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,14 @@ test:
 
 dev:
 	( \
-		pip install -U pip==18.1 pip-tools; \
+		pip install -U pip pip-tools; \
 		pip-sync requirements/dev.txt; \
 	)
 
 # to pass optional parameters use as: make pip p='-P requests'
 pip:
 	( \
-		pip install -U pip==18.1 pip-tools; \
+		pip install -U pip pip-tools; \
 		pip-compile $(p) --output-file requirements/common.txt requirements/common.ini; \
 		pip-compile $(p) --output-file requirements/dev.txt requirements/dev.ini; \
 		pip-compile $(p) --output-file requirements/prod.txt requirements/prod.ini; \

--- a/requirements/dev.ini
+++ b/requirements/dev.ini
@@ -6,4 +6,4 @@ django-debug-toolbar==1.11
 invoke==1.2.0
 ipdb==0.11
 isort==4.3.4
-pip-tools==3.2.0
+pip-tools==3.3.1


### PR DESCRIPTION
Updated pip-tools version after it's last release that support pip 19.0 
and remove version constrain in Makefile.