### PR TITLE
Improve README "Usage" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Alternatively, in order to update specific dependent libraries to the latest ver
 ({{project_name}}) $ make pip p='-P urllib3'
 ```
 
-### Install libraries
+### Install libraries for development
 
 To install the just updated requirements (e.g. `requirements/dev.txt`), execute:
 


### PR DESCRIPTION
Fix #106 

There was no need to change the "Usage" title, as some of the inner sections may be used in production as well. I simply renamed the section for libraries installation, as the described procedure refers to a local/development scenario.