### PR TITLE
Fix #71 Use compatible release version specifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ migrations:
 	python manage.py makemigrations --no-header
 
 dev:
-	pip install -q pip==19.2.3 pip-tools==4.1.0
+	pip install -q pip~=19.2.3 pip-tools~=4.1.0
 	pip-sync requirements/dev.txt
 
 pip:
-	pip install -q pip==19.2.3 pip-tools==4.1.0
+	pip install -q pip~=19.2.3 pip-tools~=4.1.0
 	pip-compile $(p) requirements/common.ini > requirements/common.txt
 	pip-compile $(p) requirements/dev.ini > requirements/dev.txt
 	pip-compile $(p) requirements/prod.ini > requirements/prod.txt

--- a/requirements/common.ini
+++ b/requirements/common.ini
@@ -1,9 +1,9 @@
 # pip-compile --output-file common.txt common.ini
 
-dj-database-url==0.5.0
-dj-email-url==0.2.0
-django-configurations==2.1
-django==2.2.6
-djangorestframework==3.10.3
-psycopg2==2.8.3  # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
-python-dotenv==0.10.3
+dj-database-url~=0.5.0
+dj-email-url~=0.2.0
+django-configurations~=2.1
+django~=2.2.6
+djangorestframework~=3.10.3
+psycopg2~=2.8.3
+python-dotenv~=0.10.3

--- a/requirements/dev.ini
+++ b/requirements/dev.ini
@@ -1,8 +1,8 @@
 # pip-compile --output-file dev.txt dev.ini
 -r local.ini
 
-ansible==2.8.5
-invoke==1.3.0
-jedi==0.15.1
-pytest-django==3.5.1
-rope==0.14.0
+ansible~=2.8.5
+invoke~=1.3.0
+jedi~=0.15.1
+pytest-django~=3.5.1
+rope~=0.14.0

--- a/requirements/local.ini
+++ b/requirements/local.ini
@@ -1,7 +1,7 @@
 # pip-compile --output-file local.txt local.ini
 -r tests.ini
 
-django-debug-toolbar==2.0
-ipdb==0.12.2
-pip-tools==4.1.0
-uwsgi==2.0.18
+django-debug-toolbar~=2.0.0
+ipdb~=0.12.2
+pip-tools~=4.1.0
+uwsgi~=2.0.18.0

--- a/requirements/prod.ini
+++ b/requirements/prod.ini
@@ -1,6 +1,6 @@
 # pip-compile --output-file prod.txt prod.ini
 -r common.ini
 
-uwsgi==2.0.18
-uwsgidecorators==1.1.0
-uwsgitop==0.11
+uwsgi~=2.0.18.0
+uwsgidecorators~=1.1.0
+uwsgitop~=0.11

--- a/requirements/tests.ini
+++ b/requirements/tests.ini
@@ -2,13 +2,13 @@
 -r common.ini
 
 black==19.3b0
-coverage==4.5.4
-flake8-bugbear==19.8.0
-flake8-docstrings==1.5.0
-flake8-isort==2.7.0
-flake8-mypy==17.8.0
-flake8==3.7.8
-isort==4.3.21
+coverage~=4.5.4
+flake8-bugbear~=19.8.0
+flake8-docstrings~=1.5.0
+flake8-isort~=2.7.0
+flake8-mypy~=17.8.0
+flake8~=3.7.8
+isort~=4.3.21
 mypy==0.730
-pre-commit==1.18.3
-tox==3.14.0
+pre-commit~=1.18.3
+tox~=3.14.0


### PR DESCRIPTION
Start using compatible release as version specifiers in requirements as defined in PEP 440
https://www.python.org/dev/peps/pep-0440/#compatible-release